### PR TITLE
Fix backlight option hiding itself

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -264,8 +264,8 @@ enum SettingsDisplayItem {
 };
 
 // number of items under SettingsDisplayBacklightMode which are hidden when backlight is disabled
-static const int NUM_BACKLIGHT_SUB_ITEMS = SettingsDisplayBacklightTimeout -
-                                           SettingsDisplayBacklightMode;
+static const int NUM_BACKLIGHT_SUB_ITEMS = CLIP(SettingsDisplayBacklightTimeout -
+                                           SettingsDisplayBacklightMode - 1, 0, NumSettingsDisplayItems);
 
 static bool prv_should_show_backlight_sub_items() {
   return backlight_is_enabled();


### PR DESCRIPTION
When turning the backlight off the option disappears and you are not able to turn it back on again
This is because we move from back to front to hide the options so we accidentally move by 1 too much

Tested on silk_bb2