### PR TITLE
fw/apps/system_apps/settings_display: fix backlight self-hiding

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -264,8 +264,8 @@ enum SettingsDisplayItem {
 };
 
 // number of items under SettingsDisplayBacklightMode which are hidden when backlight is disabled
-static const int NUM_BACKLIGHT_SUB_ITEMS = SettingsDisplayBacklightTimeout -
-                                           SettingsDisplayBacklightMode;
+static const int NUM_BACKLIGHT_SUB_ITEMS = CLIP(SettingsDisplayBacklightTimeout -
+                                           SettingsDisplayBacklightMode, 0, NumSettingsDisplayItems);
 
 static bool prv_should_show_backlight_sub_items() {
   return backlight_is_enabled();


### PR DESCRIPTION
Fixes "Backlight" toggle hiding itself in display settings


### Problem

When toggling the "Backlight" option off in the display settings screen it would disappear, preventing the user from turning the backlight back on
### Solution

Changed the number of backlight sub items count to only take into account the sub items and not the main backlight setting too